### PR TITLE
Support for RISC-V from Huawei LiteOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ embOS | [Website](https://www.segger.com/embOS), [RISC-V port](https://www.segge
 RTEMS | [rtems.org](https://git.rtems.org/rtems/), [docs.rtems.org](https://docs.rtems.org/branches/master/user/bsps/bsps-riscv.html#riscv) | | Hesham Almatary
 FreeRTOS | [sourceforge](https://www.sourceforge.net/projects/freertos/) [freertos.org](https://www.freertos.org/Using-FreeRTOS-on-RISC-V.html) | | AWS
 Zephyr | [github](https://github.com/zephyrproject-rtos/zephyr/), [docs](http://docs.zephyrproject.org/boards/riscv32/index.html) | | Karol Gugala (Antmicro), Peter Gielda (Antmicro), Nathaniel Graff (SiFive)
+LiteOS | [github](https://github.com/LiteOS/LiteOS_Lab/), [docs](https://www.huaweicloud.com/product/liteos.html) | | Chaifangming (Huawei), Pengzhouhu (Huawei), Huerjia (Huawei)
 NuttX | [bitbucket.org](https://bitbucket.org/nuttx/nuttx/src/master/), [nuttx.org](http://nuttx.org/Documentation/NuttX.html#riscv) | | 
 Apache Mynewt | [riscv.org](https://riscv.org/wp-content/uploads/2016/07/Wed930_riscv_apachemynewt_v1.2.pdf) | | James Pace, Runtime
 OpenWrt | [github](https://git.openwrt.org/?p=openwrt/staging/wigyori.git;a=shortlog;h=refs/heads/kitchensink-201810), [binary repo](http://openwrt.uid0.hu) | | Zoltan Herpai


### PR DESCRIPTION
   Hi, Huawei LiteOS is a lightweight IoT operating system for IoT. It is widely used in smart home, personal wear, car networking, urban public services, manufacturing, etc, significantly reduce development and maintenance costs, effectively shorten development cycles.

   We port for RISC-V Board Links: https://github.com/LiteOS/LiteOS_Lab/tree/iot_link/targets/GD32VF103V_EVAL

  @mgielda plan to contribute more for RISC-V in the future as we can do the best, Thanks.