### PR TITLE
Add PQSE and PQSLIB / PQSoC from PQShield

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Spike | [github](https://github.com/riscv/riscv-isa-sim) | BSD 3-clause | Andrew
 Swerv-ISS  | [github](https://github.com/westerndigitalcorporation/swerv-ISS) | GPL - 3 | Joseph Rahmeh (Western Digital) 
 VLAB  | [VLAB Works](http://vlabworks.com/) | Proprietary | [ASTC](http://astc-design.com/)
 WebRISC-V | [github](https://github.com/Mariotti94/WebRISC-V)| BSD 3-clause | Gianfranco Mariotti, Roberto Giorgi  (University of Siena)
+PQSE | [website](https://pqsoc.com) | Proprietary | [PQShield](https://pqshield.com)
 
 # Object toolchain
 
@@ -177,6 +178,7 @@ Keystone Enclave | [Website](https://keystone-enclave.org), [Repositories](https
 SecureRF | [Website](https://www.securerf.com/products/), [SDK](https://info.securerf.com/iot-embedded-sdk-development-kit) | Proprietary | [SecureRF Corp.](https://www.securerf.com)
 IntrinsicID | [Quiddikey](https://www.intrinsic-id.com/products/quiddikey/) | Proprietary | [Intrinsic ID](https://www.intrinsic-id.com/)
 Penglai Enclave | [Website](http://penglai-enclave.systems), [GitHub](https://github.com/Penglai-Enclave) | Mulan PSL v1 | [IPADS](https://ipads.se.sjtu.edu.cn/)
+PQSLIB / PQSoC | [Website](https://pqsoc.com) | Proprietary | [PQShield](https://pqshield.com)
 
 # Help Wanted
 


### PR DESCRIPTION
These are being released a part of a post-quantum cryptography secure element product. PQSE is a full-system emulator (RISC-V core and cryptographic coprocessors) and PQSLIB is the software library / driver for "Pluto" RISC-V security controller.