### PR TITLE
Add riscv-rust to Simulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Swerv-ISS  | [github](https://github.com/westerndigitalcorporation/swerv-ISS) | 
 VLAB  | [VLAB Works](http://vlabworks.com/) | Proprietary | [ASTC](http://astc-design.com/)
 WebRISC-V | [github](https://github.com/Mariotti94/WebRISC-V)| BSD 3-clause | Gianfranco Mariotti, Roberto Giorgi  (University of Siena)
 PQSE | [website](https://pqsoc.com/software/) | Proprietary | [PQShield](https://pqshield.com)
+riscv-rust | [website](https://takahirox.github.io/riscv-rust/index.html) [github](https://github.com/takahirox/riscv-rust) | MIT | Takahiro Aoyagi
 
 # Object toolchain
 


### PR DESCRIPTION
I made [riscv-rust](https://github.com/takahirox/riscv-rust) emulator in Rust which emulates RISC-V processor and peripheral devices. And also it's compiled to WebAssembly so you can run [xv6-riscv](https://github.com/mit-pdos/xv6-riscv) operating system on [this online site](https://takahirox.github.io/riscv-rust/index.html). [xv6](https://pdos.csail.mit.edu/6.828/2019/xv6.html) is UNIX V6 rewritten by MIT for x86 in ANSI C. xv6-riscv is its RISC-V port.

I'm very glad if I can add my [riscv-rust](https://github.com/takahirox/riscv-rust) into Simulators.