### PR TITLE
Phoenix-RTOS real time operating system added to the riscv-software-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ RT-Thread | [github](https://github.com/RT-Thread), [rt-thread.org](https://www.
 PikeOS | [Press release](https://www.sysgo.com/news-events/news-articles/article/sysgo-adds-risc-v-support-to-its-pikeos-real-time-operating-system) | Proprietary | SYSGO
 VxWorks | [Press release](https://www.windriver.com/news/press/pr.html?ID=22570) | Proprietary | [Wind River](https://www.windriver.com)
 Embox | [github](https://github.com/embox/embox), [embox.rocks](http://www.embox.rocks/) |  | Embox
+Phoenix-RTOS | [github](https://github.com/phoenix-rtos/phoenix-rtos-doc/tree/master/quickstart/), [documentation](https://phoenix-rtos.com/documentation/) | BSD | Phoenix Systems
 
 ## BSD distributions
 


### PR DESCRIPTION
Please add Phoenix-RTOS microkernel based real time operating system to the risk-software-list in section Real-time Operating System.

Thank you in advance. 