### PR TITLE
Clarify the simulation information of OVPsim and riscvOVPsimPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ riscvOVPsimPlus | [website](https://www.ovpworld.org/riscvOVPsimPlus/) | [Propri
 DBT-RISE-RISCV | [github](https://github.com/Minres/DBT-RISE-RISCV) | BSD 3-Clause | [MINRES Technologies](https://www.minres.com/)
 FireSim | [website](https://fires.im), [mailing list](https://groups.google.com/forum/#!forum/firesim), [github](https://github.com/firesim/firesim), [ISCA 2018 Paper](https://sagark.org/assets/pubs/firesim-isca2018.pdf) | BSD | Sagar Karandikar, Howard Mao, Donggyu Kim, David Biancolin, Alon Amid, [Berkeley Architecture Research](https://bar.eecs.berkeley.edu)
 gem5 | [SW-dev thread](https://groups.google.com/a/groups.riscv.org/forum/#!topic/sw-dev/se0TVeaA_JI), [repository](https://gem5.googlesource.com/public/gem5/) | BSD-style | Alec Roelke (University of Virginia)
-Imperas | [website](http://www.imperas.com/riscv) | commercial | [Imperas](http://www.imperas.com/riscv)
-riscvOVPsim | [github](https://github.com/riscv-ovpsim/imperas-riscv-tests) | [Proprietary freeware](https://www.ovpworld.org/licenses/OVP_FP_LICENSE.pdf) | [Imperas](http://www.imperas.com/riscv)
-OVPsim | [website](http://www.ovpworld.org/riscv) | [Proprietary freeware](https://www.ovpworld.org/licenses/OVP_FP_LICENSE.pdf) | [Imperas](http://www.imperas.com/)
+OVPsim | [website](https://www.ovpworld.org/info_riscv), [github](https://github.com/riscv-ovpsim/imperas-riscv-tests) | [Proprietary](https://www.ovpworld.org/licenses/OVP_FP_LICENSE.pdf) (core simulation platform), Apache License (processor / platform model) | [Imperas](http://www.imperas.com/)
 jor1k | [website](http://s-macke.github.io/jor1k/demos/riscv.html), [github](https://github.com/s-macke/jor1k/) | BSD 2-Clause | Sebastian Macke
 Jupiter | [github](https://github.com/andrescv/Jupiter) | GPL-3.0 | Andrés Castellanos
 MARSS-RISCV | [github](https://github.com/bucaps/marss-riscv) | MIT | Gaurav N Kothari, Parikshit P Sarnaik, Gokturk Yuksek (State University of New York at Binghamton)


### PR DESCRIPTION
OVPsim is developed and maintained by Imperas. The core simulation
platform is proprietary software; it is available free of charge for
non-commercial usage. Various processor (RISC-V included), peripheral
and platform models are available as free software under the Apache
License version 2.0.

This patch removed the duplicated entries and distinguished beteween
OVPsim and riscvOVPsimPlus.