### PR TITLE
Add T-Head JianChi CDK into IDE section

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Node.js | [github](https://github.com/v8-riscv/node) | MIT | [RIOS](http://riosl
 
 Name | Links | License | Maintainers
 ---- | ----- | ------- | -----------
+JianChi CDK | [website](https://occ.t-head.cn/activities/cdk?spm=a2cl5.14290816.0.0.d3ef180fHZTODv) | Alibaba commercial license | [T-Head (Alibaba group)](https://occ.t-head.cn/)
 Imperas M\*SDK | [Website](https://www.imperas.com/msdk-advanced-multicore-software-development-kit) | Proprietary | [Imperas](https://www.imperas.com/)
 GNU MCU Eclipse | [Website](https://gnu-mcu-eclipse.github.io), [Repositories](https://github.com/gnu-mcu-eclipse), [Binary distribution](https://github.com/gnu-mcu-eclipse/org.eclipse.epp.packages/releases/) |	EPL-1.0 / various	| Liviu Ionescu
 RT-Thread Studio | [Website](https://www.rt-thread.io/download.html?download=Studio)| EPL-1.0 / various| [RT-Thread](https://www.rt-thread.io/)


### PR DESCRIPTION
1 Support XuanTie E902 RV32 CoreIP;
2 Support RV32 Core list : RV32EC, RV32EMC,RV32I,RV32IC,RV32IM,RV32IMAC,RV32IMC
![image](https://user-images.githubusercontent.com/61818886/98781763-df1ab900-2431-11eb-9140-fe6eaf521ef5.png)
