### PR TITLE
Add RustSBI to bootloader software list

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ coreboot | [Upstream](https://review.coreboot.org/cgit/coreboot.git/) | GPLv2 | 
 U-Boot | [Upstream](https://gitlab.denx.de/u-boot/u-boot) | GPLv2 | Rick Chen (Andes)
 Proxy Kernel/BBL | [GitHub](https://github.com/riscv/riscv-pk) | BSD 3-clause | SiFive
 OpenSBI | [GitHub](https://github.com/riscv/opensbi) | BSD 2-clause | Anup Patel (Western Digital), Atish Patra (Western Digital)
+RustSBI | [GitHub](https://github.com/luojia65/rustsbi) | Mulan PSL v2 | Luo Jia (Huazhong Univ. of Sci. & Tech.)
 
 # Hypervisors and related tools
 


### PR DESCRIPTION
RustSBI is already recorded into RISC-V SBI standard, its implementation ID is 4.